### PR TITLE
Improve CUDA 11 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,14 @@ name = "cellstitch-cuda"
 version = "1.5.7"
 description = "CUDA-accelerated CellStitch 3D labeling using Instanseg segmentation."
 readme = "README.md"
-authors = [{name = "Tom van Leeuwen", email = "tom@tleeuwen.nl"}]
+authors = [{ name = "Tom van Leeuwen", email = "tom@tleeuwen.nl" }]
 classifiers = [
     "Environment :: GPU :: NVIDIA CUDA :: 11",
     "Environment :: GPU :: NVIDIA CUDA :: 12",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Operating System :: Microsoft :: Windows",
-    "Topic :: Scientific/Engineering :: Image Processing"
+    "Topic :: Scientific/Engineering :: Image Processing",
 ]
 keywords = ["3D labeling", "cell labels", "2D stitching"]
 dependencies = [
@@ -25,7 +25,7 @@ dependencies = [
     "sphinxcontrib-apidoc",
     "tifffile",
     "numpy",
-    "cupy-cuda12x",
+    "cupy-cuda12x; extra != \"cuda11\"",
     "joblib",
     "fill-voids",
 ]
@@ -47,7 +47,7 @@ tag = true
 push = true
 
 [tool.bumpver.file_patterns]
-"pyproject.toml" = [
-    '^version = "{version}"',
-    '^current_version = "{version}"',
-]
+"pyproject.toml" = ['^version = "{version}"', '^current_version = "{version}"']
+
+[project.optional-dependencies]
+cuda11 = ["cupy-cuda11x"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 keywords = ["3D labeling", "cell labels", "2D stitching"]
 dependencies = [
     "instanseg-torch>=0.1.1",
-    "cellpose>=4.0.8",
+    "cellpose>=3",
     "POT>=0.8.1",
     "sphinx",
     "sphinxcontrib-apidoc",


### PR DESCRIPTION
This pull request updates the `pyproject.toml` configuration to improve dependency management and clarify project metadata. The main changes include adjusting how the `cupy` dependency is specified for different CUDA versions and adding an optional dependency group for CUDA 11 support.

Dependency management improvements:
* Modified the `cupy-cuda12x` dependency to only be installed when the `cuda11` extra is not specified, preventing conflicts between CUDA versions.
* Added an `[project.optional-dependencies]` section with a `cuda11` group, allowing users to install `cupy-cuda11x` when needed for CUDA 11 environments.

Project metadata updates:
* Fixed a minor issue in the `classifiers` list by adding a missing comma for consistency.
* Simplified the `tool.bumpver.file_patterns` section to a single-line format for improved readability.